### PR TITLE
Add AI YouTube Shorts automation CLI with local generator and OpenAI fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+output/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# AI Shorts Automation Software
+
+`shorts-automation` is a lightweight Python CLI that generates a complete YouTube Shorts production package from a single topic prompt.
+
+## What it creates
+
+Given a topic, the tool generates:
+
+- A **title**, **description**, and **hashtags**
+- A full **voiceover script** with hook + CTA
+- A timestamped **scene-by-scene shot list**
+- A production **checklist** for exporting and uploading
+- Output as both JSON (`shorts_project.json`) and Markdown (`shorts_project.md`)
+
+## Install
+
+```bash
+python -m pip install -e .
+```
+
+## Usage
+
+```bash
+shorts-automation "AI tools for creators" \
+  --angle "problem-solution" \
+  --audience "beginner creators" \
+  --duration 35 \
+  --output output/creators-short
+```
+
+Or without installation:
+
+```bash
+PYTHONPATH=src python -m shorts_automation.cli "AI side hustles"
+```
+
+## Optional OpenAI mode
+
+If `OPENAI_API_KEY` is set and the `openai` Python package is installed, the generator attempts to use OpenAI for richer scripts. If anything fails, it automatically falls back to local deterministic generation.
+
+## Output example
+
+After running, the output directory contains:
+
+- `shorts_project.json`
+- `shorts_project.md`
+
+These files are ready for editors, content teams, or downstream automation workflows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "shorts-automation"
+version = "0.1.0"
+description = "AI-powered YouTube Shorts automation CLI"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+shorts-automation = "shorts_automation.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/shorts_automation/__init__.py
+++ b/src/shorts_automation/__init__.py
@@ -1,0 +1,5 @@
+"""AI shorts automation package."""
+
+from .generator import GenerationOptions, ShortsGenerator
+
+__all__ = ["GenerationOptions", "ShortsGenerator"]

--- a/src/shorts_automation/cli.py
+++ b/src/shorts_automation/cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .generator import GenerationOptions, ShortsGenerator
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="shorts-automation",
+        description="Create an AI-powered YouTube Shorts production package.",
+    )
+    parser.add_argument("topic", help="Shorts topic, e.g. 'AI tools for students'")
+    parser.add_argument("--angle", default="educational", help="Creative angle")
+    parser.add_argument("--audience", default="general", help="Target audience")
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=30,
+        help="Target duration in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--output",
+        default="output",
+        help="Directory where JSON and markdown plan will be saved",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    options = GenerationOptions(
+        topic=args.topic,
+        angle=args.angle,
+        duration_seconds=args.duration,
+        audience=args.audience,
+    )
+
+    project = ShortsGenerator().generate(options)
+    output_dir = Path(args.output)
+    project.write(output_dir)
+
+    print("✅ Shorts automation package generated")
+    print(f"Topic: {project.topic}")
+    print(f"Title: {project.title}")
+    print(f"Files written to: {output_dir.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shorts_automation/generator.py
+++ b/src/shorts_automation/generator.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+from .models import Scene, ShortsProject
+
+
+@dataclass
+class GenerationOptions:
+    topic: str
+    angle: str = "educational"
+    duration_seconds: int = 30
+    audience: str = "general"
+
+
+class ShortsGenerator:
+    def generate(self, options: GenerationOptions) -> ShortsProject:
+        openai_key = os.getenv("OPENAI_API_KEY")
+        if openai_key:
+            try:
+                return self._generate_with_openai(options)
+            except Exception:
+                # Graceful fallback when API/network/parsing fails
+                return self._generate_local(options)
+        return self._generate_local(options)
+
+    def _generate_local(self, options: GenerationOptions) -> ShortsProject:
+        scene_count = max(4, min(7, options.duration_seconds // 5))
+        seconds_per_scene = max(3, options.duration_seconds // scene_count)
+
+        hook = f"Stop scrolling: {options.topic.title()} in {options.duration_seconds} seconds."
+        cta = "Follow for more bite-sized AI-powered shorts ideas."
+
+        scenes: list[Scene] = []
+        narration_lines: list[str] = []
+
+        for idx in range(scene_count):
+            start = idx * seconds_per_scene
+            end = min(options.duration_seconds, start + seconds_per_scene)
+            point = idx + 1
+            narration = (
+                f"Point {point}: {options.topic} insight focused on {options.angle} for {options.audience} viewers."
+            )
+            subtitle = f"{options.topic.title()} Tip {point}"
+            visual_prompt = (
+                f"Vertical cinematic b-roll illustrating {options.topic}, dynamic motion, high contrast, scene {point}."
+            )
+            scenes.append(
+                Scene(
+                    start_second=start,
+                    end_second=end,
+                    visual_prompt=visual_prompt,
+                    narration_line=narration,
+                    subtitle=subtitle,
+                )
+            )
+            narration_lines.append(narration)
+
+        title = f"{options.topic.title()} in {options.duration_seconds}s (AI Shorts Blueprint)"
+        description = (
+            f"Fast breakdown on {options.topic}. Built for {options.audience} viewers with an "
+            f"{options.angle} angle. Use this script to produce your next YouTube Short."
+        )
+        hashtags = [
+            "#shorts",
+            "#youtubeshorts",
+            "#ai",
+            f"#{options.topic.replace(' ', '')}",
+        ]
+        voiceover_script = f"{hook} " + " ".join(narration_lines) + f" {cta}"
+
+        return ShortsProject(
+            topic=options.topic,
+            angle=options.angle,
+            hook=hook,
+            cta=cta,
+            title=title,
+            description=description,
+            hashtags=hashtags,
+            voiceover_script=voiceover_script,
+            scenes=scenes,
+        )
+
+    def _generate_with_openai(self, options: GenerationOptions) -> ShortsProject:
+        from openai import OpenAI
+
+        client = OpenAI()
+        prompt = (
+            "Generate a YouTube Shorts production plan as strict JSON with keys: "
+            "title, description, hashtags (array), hook, cta, voiceover_script, scenes (array). "
+            "Each scene must have start_second, end_second, visual_prompt, narration_line, subtitle. "
+            f"Topic: {options.topic}. Angle: {options.angle}. Audience: {options.audience}. "
+            f"Duration target: {options.duration_seconds} seconds."
+        )
+
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are an expert viral short-form video producer.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.7,
+        )
+
+        content = response.choices[0].message.content or "{}"
+        payload = json.loads(content)
+        scenes = [Scene(**scene) for scene in payload["scenes"]]
+
+        return ShortsProject(
+            topic=options.topic,
+            angle=options.angle,
+            hook=payload["hook"],
+            cta=payload["cta"],
+            title=payload["title"],
+            description=payload["description"],
+            hashtags=payload["hashtags"],
+            voiceover_script=payload["voiceover_script"],
+            scenes=scenes,
+        )

--- a/src/shorts_automation/models.py
+++ b/src/shorts_automation/models.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+import json
+
+
+@dataclass
+class Scene:
+    start_second: int
+    end_second: int
+    visual_prompt: str
+    narration_line: str
+    subtitle: str
+
+
+@dataclass
+class ShortsProject:
+    topic: str
+    angle: str
+    hook: str
+    cta: str
+    title: str
+    description: str
+    hashtags: list[str]
+    voiceover_script: str
+    scenes: list[Scene]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["scenes"] = [asdict(scene) for scene in self.scenes]
+        return payload
+
+    def write(self, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / "shorts_project.json"
+        markdown_path = output_dir / "shorts_project.md"
+
+        json_path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+        markdown_lines = [
+            f"# AI Shorts Plan: {self.topic}",
+            "",
+            f"## Title\n{self.title}",
+            "",
+            "## Description",
+            self.description,
+            "",
+            f"## Hashtags\n{' '.join(self.hashtags)}",
+            "",
+            "## Hook",
+            self.hook,
+            "",
+            "## Voiceover Script",
+            self.voiceover_script,
+            "",
+            "## Shot List",
+        ]
+
+        for scene in self.scenes:
+            markdown_lines.extend(
+                [
+                    f"### {scene.start_second}s - {scene.end_second}s",
+                    f"- Visual prompt: {scene.visual_prompt}",
+                    f"- Narration: {scene.narration_line}",
+                    f"- Subtitle: {scene.subtitle}",
+                    "",
+                ]
+            )
+
+        markdown_lines.extend(
+            [
+                "## CTA",
+                self.cta,
+                "",
+                "## Production Checklist",
+                "- [ ] Generate voiceover audio",
+                "- [ ] Gather or generate vertical clips (9:16)",
+                "- [ ] Add subtitles and hook text",
+                "- [ ] Sync cuts to narration pacing",
+                "- [ ] Export MP4 (1080x1920)",
+                "- [ ] Upload and schedule",
+            ]
+        )
+
+        markdown_path.write_text("\n".join(markdown_lines), encoding="utf-8")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from shorts_automation.generator import GenerationOptions, ShortsGenerator
+
+
+class ShortsGeneratorTests(unittest.TestCase):
+    def test_local_generation_contains_required_sections(self) -> None:
+        generator = ShortsGenerator()
+        options = GenerationOptions(topic="ai productivity", duration_seconds=30)
+
+        project = generator._generate_local(options)
+
+        self.assertTrue(project.title)
+        self.assertGreaterEqual(len(project.scenes), 4)
+        self.assertIn("#shorts", project.hashtags)
+        self.assertIn("Stop scrolling", project.voiceover_script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a simple CLI to generate end-to-end YouTube Shorts production plans (title, description, hashtags, voiceover script, timestamped scenes, and a production checklist) from a single topic prompt.
- Support both a deterministic local generator for offline use and an optional OpenAI-backed generator for richer outputs, with graceful fallback on errors.

### Description
- Add a new Python package `shorts_automation` with a CLI entrypoint (`src/shorts_automation/cli.py`) and package metadata in `pyproject.toml` to install the `shorts-automation` command. 
- Implement data models and file writers in `src/shorts_automation/models.py` that export both `shorts_project.json` and `shorts_project.md`. 
- Implement the generation engine in `src/shorts_automation/generator.py` with `_generate_local` for deterministic scene/script creation and `_generate_with_openai` that uses the OpenAI client when `OPENAI_API_KEY` is set, plus automatic fallback to local generation on errors. 
- Add documentation (`README.md`) and a `.gitignore`, and include a unit test (`tests/test_generator.py`) that verifies the local generator produces required sections. 

### Testing
- Ran `python -m unittest discover -s tests` and the test suite passed (`OK`).
- Ran the CLI end-to-end with `PYTHONPATH=src python -m shorts_automation.cli "AI shorts automation" --duration 25 --output output/demo` and it completed successfully and wrote the output files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995eec590348323b653cd2331f7430e)